### PR TITLE
Remove user-level CUD routes from Question Service

### DIFF
--- a/backend/question_service/src/controllers/questionuser.js
+++ b/backend/question_service/src/controllers/questionuser.js
@@ -8,13 +8,13 @@ userQuestionRouter.get('/', questionmanager.getQuestions);
 // PATH: GET /questions/:num_qn
 userQuestionRouter.get('/:qn_num', questionmanager.getQuestions);
 
-// PATH: POST /questions
-userQuestionRouter.post('/', questionmanager.createQuestion);
+// // PATH: POST /questions
+// userQuestionRouter.post('/', questionmanager.createQuestion);
 
-// PATH: PUT /questions/:qn_num
-userQuestionRouter.put('/:qn_num', questionmanager.updateQuestion);
+// // PATH: PUT /questions/:qn_num
+// userQuestionRouter.put('/:qn_num', questionmanager.updateQuestion);
 
-// PATH: DELETE /questions/:qn_num
-userQuestionRouter.delete('/:qn_num', questionmanager.deleteQuestion);
+// // PATH: DELETE /questions/:qn_num
+// userQuestionRouter.delete('/:qn_num', questionmanager.deleteQuestion);
 
 module.exports = userQuestionRouter;


### PR DESCRIPTION
Noticed that these routes were still present so I have removed it. 
- Only Admin should be able to Create, Update, Delete questions (GET is retained)
- Any backend services that may require these routes can access via `/admin/questions` instead of `/questions`

